### PR TITLE
Customer revenue

### DIFF
--- a/ar_eda.sql
+++ b/ar_eda.sql
@@ -35,7 +35,7 @@ GROUP BY smp_customer_organization_id, EXTRACT(YEAR FROM smp_ship_date)
 HAVING EXTRACT(YEAR FROM smp_ship_date) = 2024
 ORDER BY total_revenue DESC;
 
--- TOTAL
+-- CUSTOMER BOTH YEARS -- 
 -- M030-MORGO	$8,844,478.79
 SELECT smp_customer_organization_id, SUM(smp_shipment_total)::NUMERIC::MONEY AS total_revenue
 FROM shipments 
@@ -71,6 +71,74 @@ WITH revenue_2024 AS (
 )
 SELECT SUM(total_revenue) AS total_revenue
 FROM revenue_2024;
+
+
+-- USING sales_orders TABLE --
+-- 2023 COMPANY REVENUE --
+-- $22,567,497.02
+WITH revenue AS (
+    SELECT 
+        DISTINCT omp_sales_order_id,
+        EXTRACT(YEAR FROM omp_order_date) AS year,
+        SUM(omp_order_total_base::NUMERIC::MONEY) AS total_order_value
+    FROM sales_orders
+    GROUP BY omp_sales_order_id, omp_order_date
+    HAVING EXTRACT(YEAR FROM omp_order_date) = 2023
+    ORDER BY total_order_value DESC
+)
+SELECT SUM(total_order_value) AS total_revenue
+FROM revenue; 
+
+-- 2024 COMPANY REVENUE --
+-- $16,225,617.39
+WITH revenue AS (
+    SELECT 
+        DISTINCT omp_sales_order_id,
+        EXTRACT(YEAR FROM omp_order_date) AS year,
+        SUM(omp_order_total_base::NUMERIC::MONEY) AS total_order_value
+    FROM sales_orders
+    GROUP BY omp_sales_order_id, omp_order_date
+    HAVING EXTRACT(YEAR FROM omp_order_date) = 2024
+    ORDER BY total_order_value DESC
+)
+SELECT SUM(total_order_value) AS total_revenue
+FROM revenue; 
+
+
+-- 2023 CUSTOMER REVENUE -- 
+-- M030-MORGO	$7,264,747.93
+SELECT 
+    EXTRACT(YEAR FROM omp_order_date) AS year, 
+    omp_customer_organization_id, 
+    SUM(omp_order_subtotal_base)::NUMERIC::MONEY AS total_revenue
+FROM sales_orders
+GROUP BY omp_customer_organization_id, EXTRACT(YEAR FROM omp_order_date)
+HAVING EXTRACT(YEAR FROM omp_order_date) = 2023
+ORDER BY total_revenue DESC;
+
+
+-- 2024 CUSTOMER REVENUE -- 
+-- Y002-YNGTC	$4,831,083.83
+SELECT 
+    EXTRACT(YEAR FROM omp_order_date) AS year, 
+    omp_customer_organization_id, 
+    SUM(omp_order_subtotal_base)::NUMERIC::MONEY AS total_revenue
+FROM sales_orders
+GROUP BY omp_customer_organization_id, EXTRACT(YEAR FROM omp_order_date)
+HAVING EXTRACT(YEAR FROM omp_order_date) = 2024
+ORDER BY total_revenue DESC;
+
+
+-- CUSTOMER BOTH YEARS -- 
+-- M030-MORGO	$8,458,041.04
+SELECT 
+    omp_customer_organization_id, 
+    SUM(omp_order_subtotal_base)::NUMERIC::MONEY AS total_revenue
+FROM sales_orders
+GROUP BY omp_customer_organization_id
+ORDER BY total_revenue DESC;
+
+
 
 -- 1.b 
 --------------------------------------------------------------------------------
@@ -156,14 +224,19 @@ SELECT
     SUM(total_revenue_per_customer) AS total_revenue
 FROM revenue;
 
+SELECT *
+FROM sales_orders
+LIMIT 5;
 
 -- this is closer : not divided by year
 WITH revenue AS (
     SELECT 
         DISTINCT omp_sales_order_id,
+        EXTRACT(YEAR FROM omp_order_date) AS year,
         SUM(omp_order_total_base::NUMERIC::MONEY) AS total_order_value
     FROM sales_orders
-    GROUP BY omp_sales_order_id
+    GROUP BY omp_sales_order_id, omp_order_date
+    HAVING EXTRACT(YEAR FROM omp_order_date) = 2023
     ORDER BY total_order_value DESC
 )
 SELECT SUM(total_order_value) AS total_revenue
@@ -307,13 +380,13 @@ FROM jobs
 SELECT
     COUNT(DISTINCT jmp_customer_organization_id) AS n_returning_customers
 FROM jobs
-HAVING COUNT(jmp_customer_organization_id) > 1;
--- WHERE jmp_customer_organization_id IN (
---     SELECT DISTINCT jmp_customer_organization_id
---     FROM jobs
---     GROUP BY jmp_customer_organization_id
---     HAVING COUNT(jmp_customer_organization_id) > 1
--- );
+-- HAVING COUNT(jmp_customer_organization_id) > 1;
+WHERE jmp_customer_organization_id IN (
+    SELECT DISTINCT jmp_customer_organization_id
+    FROM jobs
+    GROUP BY jmp_customer_organization_id
+    HAVING COUNT(jmp_customer_organization_id) > 1
+);
 
 
 

--- a/ar_eda.sql
+++ b/ar_eda.sql
@@ -18,8 +18,7 @@ For your project, your group will be responsible for one of the following sets o
 
 -- 1.a 
 --------------------------------------------------------------------------------
--- Revenue and job counts generated per customer 
--- 
+-- REVENUE --
 -- 2023
 -- 	2023	M030-MORGO	$7,720,776.64
 SELECT EXTRACT(YEAR FROM smp_ship_date) AS year, smp_customer_organization_id, SUM(smp_shipment_total)::NUMERIC::MONEY AS total_revenue
@@ -36,6 +35,42 @@ GROUP BY smp_customer_organization_id, EXTRACT(YEAR FROM smp_ship_date)
 HAVING EXTRACT(YEAR FROM smp_ship_date) = 2024
 ORDER BY total_revenue DESC;
 
+-- TOTAL
+-- M030-MORGO	$8,844,478.79
+SELECT smp_customer_organization_id, SUM(smp_shipment_total)::NUMERIC::MONEY AS total_revenue
+FROM shipments 
+GROUP BY smp_customer_organization_id
+ORDER BY total_revenue DESC;
+
+-- TOTAL COMPANY REVENUE 2023 --
+-- $23,092,060.67
+WITH revenue_2023 AS (
+    SELECT 
+        EXTRACT(YEAR FROM smp_ship_date) AS year,
+        smp_customer_organization_id, 
+        SUM(smp_shipment_total)::NUMERIC::MONEY AS total_revenue
+    FROM shipments 
+    GROUP BY smp_customer_organization_id, EXTRACT(YEAR FROM smp_ship_date)
+    HAVING EXTRACT(YEAR FROM smp_ship_date) = 2023
+    ORDER BY total_revenue DESC
+)
+SELECT SUM(total_revenue) AS total_revenue
+FROM revenue_2023;
+
+-- TOTAL COMPANY REVENUE 2024 --
+-- $15,190,447.63
+WITH revenue_2024 AS (
+    SELECT 
+        EXTRACT(YEAR FROM smp_ship_date) AS year,
+        smp_customer_organization_id, 
+        SUM(smp_shipment_total)::NUMERIC::MONEY AS total_revenue
+    FROM shipments 
+    GROUP BY smp_customer_organization_id, EXTRACT(YEAR FROM smp_ship_date)
+    HAVING EXTRACT(YEAR FROM smp_ship_date) = 2024
+    ORDER BY total_revenue DESC
+)
+SELECT SUM(total_revenue) AS total_revenue
+FROM revenue_2024;
 
 -- 1.b 
 --------------------------------------------------------------------------------

--- a/ar_eda.sql
+++ b/ar_eda.sql
@@ -10,7 +10,7 @@ A few tips for navigating the database: Each job can have multiple job operation
 For your project, your group will be responsible for one of the following sets of questions. Construct an R Shiny app to show your findings.
 
 **1. Do an analysis of customers. The customer can be identified using the jmp_customer_organization_id from the jobs table or the omp_customer_organization_id from the sales_orders table. Here are some example questions to get started:  
-    a. Which customers have the highest volume of jobs? Which generate the most revenue (as indicated by the omp_order_subtotal_base in the sales_order table)?  
+    a. Which customers have the highest volume of jobs? Which generate the most revenue (as indicated by the omp_order_subtotal_base (Ian recommended we use the total in the shipments table for revenue calculations) in the sales_order table)?  
     b. How has the volume of work changed for each customer over time? Are there any seasonal patterns? How have the number of estimated hours per customer changed over time? Estimated hours are in the jmo_estimated_production_hours columns of the job_operations_2023/job_operations_2024 tables.  
     c. How has the customer base changed over time? What percentage of jobs are for new customers compared to repeat customers?  
     d. Perform a breakdown of customers by operation (as indicated by the jmo_process short_description in the job_operations_2023 or job_operations_2024 table).** */
@@ -157,7 +157,7 @@ SELECT
 FROM revenue;
 
 
--- this is closer
+-- this is closer : not divided by year
 WITH revenue AS (
     SELECT 
         DISTINCT omp_sales_order_id,


### PR DESCRIPTION
Customer Revenue broken down by year and in a few categories using two different tables:

it was recommended to use the shipments table to get the most accurate revenue numbers, so that was used first.
the customer who generated the highest revenue was found for the years 2023 and 2024, as well as the combination of both years.

the total company revenue was calculated using the sum of these figures by year.

the same was then calculated using the sales_orders table. Results were similar, though slightly different. This is what was expected.
